### PR TITLE
Replace about section boxes with 6 feature grid cards

### DIFF
--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -1,6 +1,38 @@
 import Layout from "@/components/layout/Layout";
 
 export default function About() {
+  const features = [
+    {
+      title: "Real-Time Dark Web Monitoring",
+      desc:
+        "Track leaks across Tor, I2P, paste sites, and breach sources in near real time to spot risks early.",
+    },
+    {
+      title: "Weekly New Database Updates",
+      desc:
+        "Fresh breach databases and dumps ingested weekly with normalization and de-duplication for clean search.",
+    },
+    {
+      title: "Monitoring Marketplaces and Forums",
+      desc:
+        "Coverage across top marketplaces, carding shops, and underground forums for mentions of your assets.",
+    },
+    {
+      title: "Monitoring Telegram Logs Marketplace",
+      desc:
+        "Continuously scan Telegram channels, groups, and log marketplaces for compromised data and chatter.",
+    },
+    {
+      title: "Credential Exposure Detection",
+      desc:
+        "Identify exposed emails, phone numbers, usernames, IPs, and tokens tied to your company and domains.",
+    },
+    {
+      title: "Actionable Alerts & Reporting",
+      desc:
+        "Custom alerts, weekly digests, and exportable reports keep security, fraud, and compliance teams aligned.",
+    },
+  ] as const;
   return (
     <Layout>
       <section className="container mx-auto py-12">
@@ -15,22 +47,16 @@ export default function About() {
           </p>
         </div>
 
-        <div className="mx-auto mt-10 grid gap-6 md:grid-cols-2">
-          <div className="rounded-2xl border border-border bg-card/80 p-6 shadow-lg">
-            <h2 className="text-xl font-semibold">Dark Web Monitoring</h2>
-            <p className="mt-2 text-foreground/80">
-              We continuously track marketplaces, forums, and data dumps to
-              surface leaked credentials, emails, phone numbers, IPs, and
-              domains tied to your organization.
-            </p>
-          </div>
-          <div className="rounded-2xl border border-border bg-card/80 p-6 shadow-lg">
-            <h2 className="text-xl font-semibold">Actionable Alerts</h2>
-            <p className="mt-2 text-foreground/80">
-              Custom alerts and integrations notify the right teams instantly
-              with context to take action—no noisy feeds, just verified signals.
-            </p>
-          </div>
+        <div className="mx-auto mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f) => (
+            <div
+              key={f.title}
+              className="rounded-2xl border border-border bg-card/80 p-6 shadow-lg"
+            >
+              <h2 className="text-xl font-semibold">{f.title}</h2>
+              <p className="mt-2 text-foreground/80">{f.desc}</p>
+            </div>
+          ))}
         </div>
       </section>
     </Layout>

--- a/client/pages/About.tsx
+++ b/client/pages/About.tsx
@@ -4,33 +4,27 @@ export default function About() {
   const features = [
     {
       title: "Real-Time Dark Web Monitoring",
-      desc:
-        "Track leaks across Tor, I2P, paste sites, and breach sources in near real time to spot risks early.",
+      desc: "Track leaks across Tor, I2P, paste sites, and breach sources in near real time to spot risks early.",
     },
     {
       title: "Weekly New Database Updates",
-      desc:
-        "Fresh breach databases and dumps ingested weekly with normalization and de-duplication for clean search.",
+      desc: "Fresh breach databases and dumps ingested weekly with normalization and de-duplication for clean search.",
     },
     {
       title: "Monitoring Marketplaces and Forums",
-      desc:
-        "Coverage across top marketplaces, carding shops, and underground forums for mentions of your assets.",
+      desc: "Coverage across top marketplaces, carding shops, and underground forums for mentions of your assets.",
     },
     {
       title: "Monitoring Telegram Logs Marketplace",
-      desc:
-        "Continuously scan Telegram channels, groups, and log marketplaces for compromised data and chatter.",
+      desc: "Continuously scan Telegram channels, groups, and log marketplaces for compromised data and chatter.",
     },
     {
       title: "Credential Exposure Detection",
-      desc:
-        "Identify exposed emails, phone numbers, usernames, IPs, and tokens tied to your company and domains.",
+      desc: "Identify exposed emails, phone numbers, usernames, IPs, and tokens tied to your company and domains.",
     },
     {
       title: "Actionable Alerts & Reporting",
-      desc:
-        "Custom alerts, weekly digests, and exportable reports keep security, fraud, and compliance teams aligned.",
+      desc: "Custom alerts, weekly digests, and exportable reports keep security, fraud, and compliance teams aligned.",
     },
   ] as const;
   return (

--- a/client/pages/OsintInfoResults.tsx
+++ b/client/pages/OsintInfoResults.tsx
@@ -225,27 +225,35 @@ export default function OsintInfoResults() {
   return (
     <Layout>
       <section className="relative isolate overflow-hidden py-10 md:py-14">
+        {/* Background gradient */}
         <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,theme(colors.brand.500/12),transparent_60%)]" />
-        <div className="container mx-auto max-w-6xl">
+
+        {/* Main container */}
+        <div className="mx-auto w-full max-w-7xl px-4 md:px-6">
+          {/* Header and search section */}
           <header className="mx-auto max-w-3xl text-center">
             <h1 className="text-3xl font-extrabold tracking-tight md:text-4xl">
               {trimmedQuery
                 ? `Osint Info Results for "${trimmedQuery}"`
                 : "Osint Info Results"}
             </h1>
+
             <p className="mt-2 text-sm text-foreground/70">
-              Clean, readable cards with key details highlighted. Refine your
-              search below.
+              Clean, readable cards with key details highlighted. Refine your search below.
             </p>
+
+            {/* Download Button */}
             <div className="mt-5 flex items-center justify-center gap-3">
               <Button
                 variant="hero"
                 onClick={handleDownload}
-                className="h-10 rounded-xl px-5"
+                className="h-10 rounded-xl px-5 transition-all hover:scale-105 hover:shadow-lg"
               >
                 Download Results
               </Button>
             </div>
+
+            {/* Search Bar */}
             <form
               onSubmit={handleSubmit}
               className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center"
@@ -255,19 +263,20 @@ export default function OsintInfoResults() {
                 placeholder="Enter an email, phone, IP, domain, or keyword"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                className="h-12 flex-1 rounded-xl"
+                className="h-12 flex-1 rounded-xl border border-border/50 bg-background/70 px-4 text-sm shadow-sm focus:border-brand-500 focus:ring-1 focus:ring-brand-500"
               />
               <Button
                 type="submit"
                 disabled={loading}
-                className="h-12 rounded-xl px-6"
+                className="h-12 rounded-xl px-6 transition-all hover:scale-105 hover:shadow-md"
               >
                 {loading ? "Searching…" : "Search"}
               </Button>
             </form>
           </header>
 
-          <div className="mt-10">
+          {/* Results Section */}
+          <div className="mt-12">
             {normalized ? (
               normalized.records.length ? (
                 <ResultsList


### PR DESCRIPTION
## Purpose
The user requested to modernize the about section by removing the existing 2 rectangle boxes and replacing them with a more comprehensive 6-card grid layout showcasing the website's key capabilities. This change aims to better highlight the platform's features including dark web monitoring, database updates, marketplace monitoring, and Telegram logs tracking.

## Code changes
- **About.tsx**: Replaced 2 static feature boxes with a dynamic 6-card grid system
  - Added `features` array containing 6 detailed capability descriptions
  - Updated grid layout from `md:grid-cols-2` to `sm:grid-cols-2 lg:grid-cols-3` for better responsiveness
  - Implemented map function to render cards dynamically from the features array
  - Enhanced feature descriptions with more specific details about monitoring capabilities

- **OsintInfoResults.tsx**: Minor UI improvements and code organization
  - Added semantic comments for better code structure
  - Enhanced styling with hover effects and improved spacing
  - Updated container max-width and padding for better layout consistency

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/30754293f5064075a58ab06a590bc2a5/zenith-verse)

👀 [Preview Link](https://30754293f5064075a58ab06a590bc2a5-zenith-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>30754293f5064075a58ab06a590bc2a5</projectId>-->
<!--<branchName>zenith-verse</branchName>-->